### PR TITLE
Aggressive NPC State

### DIFF
--- a/src/main/java/com/blackjack/BlackjackConfig.java
+++ b/src/main/java/com/blackjack/BlackjackConfig.java
@@ -46,11 +46,20 @@ public interface BlackjackConfig extends Config {
 	)
 	default Color knockedOutStateColor() {return Color.GREEN;}
 
+
+	@ConfigItem(
+			keyName = "aggressiveStateColor",
+			name = "NPC Aggressive State Color",
+			description = "Change the color of the aggressive state highlight",
+			position = 5
+	)
+	default Color aggressiveStateColor() {return Color.RED;}
+
 	@ConfigItem(
 			keyName = "statusText",
 			name = "Draw status text above NPCs",
 			description = "Configures whether or not to write if the target NPC is awake or knocked out",
-			position = 5
+			position = 6
 	)
 	default boolean statusText()
 	{

--- a/src/main/java/com/blackjack/BlackjackNPCState.java
+++ b/src/main/java/com/blackjack/BlackjackNPCState.java
@@ -1,7 +1,17 @@
 package com.blackjack;
 
+import lombok.Getter;
+
 public enum BlackjackNPCState {
-    AWAKEN,
-    KNOCKED_OUT,
-    AGGRESSIVE,
+    AWAKEN("Awaken"),
+    KNOCKED_OUT("Knocked Out"),
+    AGGRESSIVE("Aggressive");
+
+    @Getter
+    public String displayName;
+
+    private BlackjackNPCState(String displayName)
+    {
+        this.displayName = displayName;
+    }
 }

--- a/src/main/java/com/blackjack/BlackjackNPCState.java
+++ b/src/main/java/com/blackjack/BlackjackNPCState.java
@@ -1,0 +1,7 @@
+package com.blackjack;
+
+public enum BlackjackNPCState {
+    AWAKEN,
+    KNOCKED_OUT,
+    AGGRESSIVE,
+}

--- a/src/main/java/com/blackjack/BlackjackOverlay.java
+++ b/src/main/java/com/blackjack/BlackjackOverlay.java
@@ -1,6 +1,5 @@
 package com.blackjack;
 
-import lombok.SneakyThrows;
 import net.runelite.api.Point;
 import net.runelite.api.*;
 import net.runelite.api.coords.LocalPoint;
@@ -9,8 +8,6 @@ import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.util.Text;
-
-import java.text.SimpleDateFormat;
 
 import javax.inject.Inject;
 import java.awt.*;

--- a/src/main/java/com/blackjack/BlackjackOverlay.java
+++ b/src/main/java/com/blackjack/BlackjackOverlay.java
@@ -30,8 +30,7 @@ public class BlackjackOverlay extends Overlay {
     public Dimension render(Graphics2D graphics) {
         for (NPC npc : plugin.getHighlightedNpcs())
         {
-            Color color = plugin.getHighlightColor();
-            renderNpcOverlay(graphics, npc, color);
+            renderNpcOverlay(graphics, npc, plugin.getHighlightColor());
         }
         return null;
     }
@@ -56,7 +55,6 @@ public class BlackjackOverlay extends Overlay {
 
             case HULL:
                 Shape objectClickbox = actor.getConvexHull();
-                //client.addChatMessage(ChatMessageType.CONSOLE, "DEBUG", color.toString(), "");
                 renderPoly(graphics, color, objectClickbox);
                 break;
         }
@@ -68,7 +66,6 @@ public class BlackjackOverlay extends Overlay {
 
             if (textLocation != null)
             {
-                //client.addChatMessage(ChatMessageType.CONSOLE, "DEBUG", plugin.statusText(), "");
                 OverlayUtil.renderTextLocation(graphics, textLocation, plugin.statusText(), color);
             }
         }

--- a/src/main/java/com/blackjack/BlackjackOverlay.java
+++ b/src/main/java/com/blackjack/BlackjackOverlay.java
@@ -1,5 +1,6 @@
 package com.blackjack;
 
+import lombok.SneakyThrows;
 import net.runelite.api.Point;
 import net.runelite.api.*;
 import net.runelite.api.coords.LocalPoint;
@@ -8,6 +9,8 @@ import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.util.Text;
+
+import java.text.SimpleDateFormat;
 
 import javax.inject.Inject;
 import java.awt.*;
@@ -30,7 +33,8 @@ public class BlackjackOverlay extends Overlay {
     public Dimension render(Graphics2D graphics) {
         for (NPC npc : plugin.getHighlightedNpcs())
         {
-            renderNpcOverlay(graphics, npc, plugin.getHighlightColor());
+            Color color = plugin.getHighlightColor();
+            renderNpcOverlay(graphics, npc, color);
         }
         return null;
     }
@@ -55,7 +59,7 @@ public class BlackjackOverlay extends Overlay {
 
             case HULL:
                 Shape objectClickbox = actor.getConvexHull();
-
+                //client.addChatMessage(ChatMessageType.CONSOLE, "DEBUG", color.toString(), "");
                 renderPoly(graphics, color, objectClickbox);
                 break;
         }
@@ -67,6 +71,7 @@ public class BlackjackOverlay extends Overlay {
 
             if (textLocation != null)
             {
+                //client.addChatMessage(ChatMessageType.CONSOLE, "DEBUG", plugin.statusText(), "");
                 OverlayUtil.renderTextLocation(graphics, textLocation, plugin.statusText(), color);
             }
         }

--- a/src/main/java/com/blackjack/BlackjackPlugin.java
+++ b/src/main/java/com/blackjack/BlackjackPlugin.java
@@ -3,7 +3,6 @@ package com.blackjack;
 import com.google.inject.Provides;
 import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
@@ -20,8 +19,6 @@ import net.runelite.client.util.WildcardMatcher;
 import javax.inject.Inject;
 import java.awt.Color;
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @PluginDescriptor(
 		name = "Blackjack",


### PR DESCRIPTION
Hi!

First of all, great work with the plugin, it's been very useful. Thank you for that!

Now the thing is, I was missing some kind of quick visual feedback also when you fail to knock out the bandit and it becomes aggressive, giving you very little time to react with another knock out or a pickpocket.
So I decided to implement this feature and submit a pull request. I'm not actually a java developer and I've never done anything using RuneLite API before, but I think I managed to achieve my objective.

I added a new NPC State becides the **Awaken** and **Knocked Out:** The **Aggressive** state, which kicks in whenever you fail to blackjack the NPC, and goes away whenever you manage to successfully knock it out or pickpocket (it doesn't matter if you fail, see the [Notes section here](https://oldschool.runescape.wiki/w/Blackjack) for more details if you wish).

Unfortunately I couldn't make the Aggressive state go away if you use the "Lure" option between his attacks. I tried looking for hooks or something like that we could use to do it, but I didn't find anything useful in my researches. It would be great if you could help with that.

I also took the liberty of refactoring the data structures involving the NPC State with a custom enum to have a cleaner structure and also making it responsible for providing its own display names.

I am open for any feedback and suggestions you have and I hope we can release this new feature for I think it will be of much use on top of the good work you've already done =)